### PR TITLE
Enforce tox < 4 to get GHA green again.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-factor
+        pip install 'tox < 4' tox-factor
     - name: Install dependencies (firefox)
       if: matrix.browser == 'ff'
       run: |


### PR DESCRIPTION
This is needed until https://github.com/tox-dev/tox/issues/2752 is solved.